### PR TITLE
Enhancement #14: observe value.* for auto-save

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -34,19 +34,29 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <div class="vertical-section vertical-section-container centered">
 
     <template is="dom-bind">
-      <p>string entered below will be stored in <code>localStorage</code> and automatically retrived from <code>localStorage</code> when the page is reloaded</p>
+      <iron-localstorage
+        name="polymer-localstorage-x-test1"
+        value="{{value}}"
+        on-iron-localstorage-load-empty="initializeDefaultValue"
+        ></iron-localstorage>
+      <p>Form element below will be kept in sync with <code>localStorage</code>.</p>
+      <p>Demo source also shows how to initialize storage to default value</p>
       <p>If you open another window with this test, changes in one window will propagate to
       the other immediately.</p>
-      <input value="{{value::change}}" placeholder="Enter words">
-      <iron-localstorage name="polymer-localstorage-x-test1" value="{{value}}"></iron-localstorage>
+      <p>Name: <input value="{{value.name::change}}" placeholder="Enter words"></p>
+      <paper-checkbox checked="{{value.hasEars::change}}">Has ears</paper-checkbox>
     </template>
 
-    <template is="dom-bind">
-      <paper-checkbox checked="{{mode::change}}">Check me</paper-checkbox>
-
-      <iron-localstorage name="polymer-localstorage-x-test2" value="{{mode}}"></iron-localstorage>
-    </template>
-  
   </div>
+
+  <script>
+    document.querySelector('template').initializeDefaultValue = function(ev) {
+      console.log("initializeTemplate");
+      this.value = {
+        name: "Mickey",
+        hasEars: true
+      }
+    }
+  </script>
 </body>
 </html>

--- a/iron-localstorage.html
+++ b/iron-localstorage.html
@@ -13,29 +13,64 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <!--
 Element access to Web Storage API (window.localStorage).
 
-Keeps `value` in sync with a localStorage key.
+Keeps `value` property in sync with localStorage.
 
-Direct assignments to `value` are automatically detected and saved.
-Subproperty assignments are not (ex: `value.bar='foo'`).
-Call `save()` manually to commit your changes after modifying subproperties.
+Value is saved as json by default.
 
-Value is saved in localStorage as JSON by default.
+###Usage:
 
-If you set the value to null, storage key will be deleted.
+`ls-sample` will automatically save changes to its value.
 
-    <iron-localstorage name="my-app-storage" value="{{value}}">
-    </iron-localstorage>
+    <dom-module id="ls-sample">
+      <iron-localstorage name="my-app-storage"
+        value="{{cartoon}}"
+        on-iron-localstorage-load-empty="initializeDefaultCartoon"
+      ></iron-localstorage>
+    </dom-module>
 
+    <script>
+      Polymer({
+        is: 'ls-sample',
+        properties: {
+          cartoon: {
+            type: Object
+          }
+        },
+        // initializes default if nothing has been stored
+        initializeDefaultCartoon: function() {
+          this.cartoon = {
+            name: "Mickey",
+            hasEars: true
+          }
+        },
+        // use path set api to propagate changes to localstorage
+        makeModifications: function() {
+          this.set('cartoon.name', "Minions");
+          this.set('cartoon.hasEars', false);
+        }
+      });
+    </script>
 
-<b>Warning</b>: do not pass subproperty bindings to iron-localstorage until Polymer
+###Tech notes:
+
+* * `value.*` is observed, and saved on modifications. You must use
+property notification methods to modify value for changes to be observed.
+
+* * Set `auto-save-disabled` to prevent automatic saving.
+
+* * Value is saved as JSON by default.
+
+* * To delete a key, set value to null
+
+* Element listens to StorageAPI `storage` event, and will reload upon receiving it.
+
+* **Warning**: do not bind value to sub-properties until Polymer
 [bug 1550](https://github.com/Polymer/polymer/issues/1550)
 is resolved. Local storage will be blown away.
-No `<iron-localstorage value="{{foo.bar}}"`.
+`<iron-localstorage value="{{foo.bar}}"` will cause **data loss**.
 
-@group Iron Elements
 @demo demo/index.html
 @hero hero.svg
-@element iron-localstorage
 -->
 <dom-module id="iron-localstorage"></dom-module>
 <script>
@@ -47,19 +82,21 @@ No `<iron-localstorage value="{{foo.bar}}"`.
      * Fired when value loads from localStorage.
      *
      * @event iron-localstorage-load
-     * @param {{externalChange: boolean}} detail -
-     *     externalChange: True if change occured in different window.
+     * @param {{externalChange:boolean}} detail -
+     *     externalChange: true if change occured in different window.
      */
 
     /**
-     * Fired when loaded value is null.
-     * You can use event handler to initialize default value.
+     * Fired when loaded value does not exist.
+     * Event handler can be used to initialize default value.
      *
      * @event iron-localstorage-load-empty
+     * @param {{externalChange:boolean}} detail -
+     *     externalChange: true if change occured in different window.
      */
     properties: {
       /**
-       * The key to the data stored in localStorage.
+       * localStorage item key
        */
       name: {
         type: String,
@@ -67,7 +104,7 @@ No `<iron-localstorage value="{{foo.bar}}"`.
       },
       /**
        * The data associated with this storage.
-       * If value is set to null, and storage is in useRaw mode, item will be deleted
+       * If set to null item will be deleted.
        * @type {*}
        */
       value: {
@@ -76,7 +113,7 @@ No `<iron-localstorage value="{{foo.bar}}"`.
       },
 
       /**
-       * Value is stored and retrieved without JSON parse if true
+       * If true: do not convert value to JSON on save/load
        */
       useRaw: {
         type: Boolean,
@@ -84,22 +121,21 @@ No `<iron-localstorage value="{{foo.bar}}"`.
       },
 
       /**
-       * Auto save is disabled if true. Default to false.
+       * Value will not be saved automatically if true. You'll have to do it manually with `save()`
        */
       autoSaveDisabled: {
         type: Boolean,
         value: false
       },
       /**
-       * Last error encountered while saving/loading items. Null otherwise
+       * Last error encountered while saving/loading items
        */
       errorMessage: {
         type: String,
         notify: true
       },
-      /*
-       * True if value was loaded
-       */
+
+      /** True if value has been loaded */
       _loaded: {
         type: Boolean,
         value: false
@@ -107,8 +143,9 @@ No `<iron-localstorage value="{{foo.bar}}"`.
     },
 
     observers: [
-      'reload(name,useRaw)',
-      '_trySaveValue(value, _loaded, autoSaveDisabled)'
+      '_debounceReload(name,useRaw)',
+      '_trySaveValue(autoSaveDisabled)',
+      '_trySaveValue(value.*)'
     ],
 
     ready: function() {
@@ -129,14 +166,17 @@ No `<iron-localstorage value="{{foo.bar}}"`.
       }
     },
 
-    _trySaveValue: function(value, _loaded, autoSaveDisabled) {
-      if (this._justLoaded) { // guard against saving after _load()
-        this._justLoaded = false;
+    _trySaveValue: function() {
+      if (this._doNotSave) {
         return;
       }
-      if (_loaded && !autoSaveDisabled) {
-        this.save();
+      if (this._loaded && !this.autoSaveDisabled) {
+        this.debounce('save', this.save);
       }
+    },
+
+    _debounceReload: function() {
+      this.debounce('reload', this.reload);
     },
 
     /**
@@ -145,6 +185,7 @@ No `<iron-localstorage value="{{foo.bar}}"`.
      * keep this element in sync.
      */
     reload: function() {
+      this._loaded = false;
       this._load();
     },
 
@@ -156,20 +197,27 @@ No `<iron-localstorage value="{{foo.bar}}"`.
       var v = window.localStorage.getItem(this.name);
 
       if (v === null) {
-        this.fire('iron-localstorage-load-empty');
-      } else if (!this.useRaw) {
-        try {
-          v = JSON.parse(v);
-        } catch(x) {
-          this.errorMessage = "Could not parse local storage value";
-          console.error("could not parse local storage value", v);
+        this._loaded = true;
+        this._doNotSave = true;  // guard for save watchers
+        this.value = null;
+        this._doNotSave = false;
+        this.fire('iron-localstorage-load-empty', { externalChange: externalChange});
+      } else {
+        if (!this.useRaw) {
+          try { // parse value as JSON
+            v = JSON.parse(v);
+          } catch(x) {
+            this.errorMessage = "Could not parse local storage value";
+            console.error("could not parse local storage value", v);
+            v = null;
+          }
         }
+        this._loaded = true;
+        this._doNotSave = true;
+        this.value = v;
+        this._doNotSave = false;
+        this.fire('iron-localstorage-load', { externalChange: externalChange});
       }
-
-      this._justLoaded = true;
-      this._loaded = true;
-      this.value = v;
-      this.fire('iron-localstorage-load', { externalChange: externalChange});
     },
 
     /**

--- a/test/basic.html
+++ b/test/basic.html
@@ -39,6 +39,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         window.localStorage.setItem('iron-localstorage-test', '{"foo":"bar"}');
         document.getElementById('fixture').create();
         storage = document.getElementById('localstorage');
+        storage.flushDebouncer('reload');
       });
 
       teardown(function() {
@@ -53,6 +54,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('save', function() {
         var newValue = {'foo': 'zot'};
         storage.value = newValue;
+        storage.flushDebouncer('save');
         var v = window.localStorage.getItem(storage.name);
         v = JSON.parse(v);
         assert.equal(v.foo, newValue.foo);
@@ -60,6 +62,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       test('delete', function() {
         storage.value = null;
+        storage.flushDebouncer('save');
         var v = window.localStorage.getItem(storage.name);
         assert.isNull(v);
       });
@@ -73,11 +76,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       test('event iron-localstorage-load-empty', function(done) {
+        window.localStorage.removeItem('iron-localstorage-test');
+
         var ls = document.createElement('iron-localstorage');
         ls.addEventListener('iron-localstorage-load-empty', function() {
+          // testing recommended way to initialize localstorage
+          ls.value = "Yo";
+          ls.flushDebouncer('save');
+          assert.equal("Yo", JSON.parse( window.localStorage.getItem('iron-localstorage-test')));
           done();
         });
-        ls.name = 'iron-localstorage-not-exist';
+        ls.name = 'iron-localstorage-test';
       });
 
     });

--- a/test/basic.html
+++ b/test/basic.html
@@ -30,6 +30,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <template id="boundTemplate" is="dom-bind">
+    <iron-localstorage id="boundLocal" name="iron-localstorage-test" value="{{value}}"></iron-localstorage>
+  </template>
+
   <script>
     var storage;
 
@@ -37,8 +41,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       setup(function() {
         window.localStorage.setItem('iron-localstorage-test', '{"foo":"bar"}');
-        document.getElementById('fixture').create();
-        storage = document.getElementById('localstorage');
+        storage = document.getElementById('fixture').create();
         storage.flushDebouncer('reload');
       });
 
@@ -87,6 +90,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           done();
         });
         ls.name = 'iron-localstorage-test';
+      });
+
+      test('auto-save sub-properties', function() {
+        var t = document.querySelector('#boundTemplate');
+        var ls = document.querySelector('#boundLocal');
+        var value = { foo: 'FOO', bar: 'BAR' };
+        t.value = value;
+        assert.equal('FOO', ls.value.foo); // value has propagated from template to storage
+
+        ls.flushDebouncer('save');
+        t.value.foo = "Yo";
+        ls.flushDebouncer('save');
+        var item = JSON.parse( window.localStorage.getItem('iron-localstorage-test'));
+        assert.notEqual('Yo', item.foo); // did not propagate because did not use setters
+
+        t.set('value.foo', 'BAZ!');
+        ls.flushDebouncer('save');
+        var item = JSON.parse( window.localStorage.getItem('iron-localstorage-test'));
+        assert.equal('BAZ!', item.foo); // did propagate
+        ls.value = null;
       });
 
     });

--- a/test/raw.html
+++ b/test/raw.html
@@ -41,6 +41,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         window.localStorage.setItem('iron-localstorage-test', 'hello world');
         document.getElementById('fixture').create();
         storage = document.getElementById('localstorage');
+        storage.flushDebouncer('reload');
       });
 
       teardown(function() {
@@ -54,6 +55,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('save', function() {
         var m = 'goodbye';
         storage.value = m;
+        storage.flushDebouncer('save');
         var v = window.localStorage.getItem(storage.name);
         assert.equal(v, m);
       });

--- a/test/value-binding.html
+++ b/test/value-binding.html
@@ -82,6 +82,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('set value', function() {
         var newValue = {'foo': 'zot'};
         xtest.value = newValue;
+        xtest.$.localstorage.flushDebouncer('save');
         var v = window.localStorage.getItem(xtest.$.localstorage.name);
         v = JSON.parse(v);
         assert.equal(v.foo, newValue.foo);


### PR DESCRIPTION
It just makes sense to always save value when it changes if auto-save is set.
This triggered some other changes:
- debouncing of save/reload because we are monitoring more changes now
- updated demo to show real-life type of usage
- that demo exposed some bugs in handling of iron-localstorage-load-empty flow,
  fixed those

Made docs clearer, better example.