### PR TITLE
Added spaces for markdown rendering

### DIFF
--- a/iron-localstorage.html
+++ b/iron-localstorage.html
@@ -17,7 +17,7 @@ Keeps `value` property in sync with localStorage.
 
 Value is saved as json by default.
 
-###Usage:
+### Usage:
 
 `ls-sample` will automatically save changes to its value.
 
@@ -51,7 +51,7 @@ Value is saved as json by default.
       });
     </script>
 
-###Tech notes:
+### Tech notes:
 
 * * `value.*` is observed, and saved on modifications. You must use
     path change notifification methods such as `set()` to modify value 


### PR DESCRIPTION
Fixed markdown rendering for 'Usage' and 'Tech Notes' headers.