### PR TITLE
wrap first call to window.localStorage in a try/catch, fixes #41

### DIFF
--- a/iron-localstorage.html
+++ b/iron-localstorage.html
@@ -179,7 +179,12 @@ is resolved. Local storage will be blown away.
      * @param {boolean=} externalChange true if loading changes from a different window
      */
     _load: function(externalChange) {
-      var v = window.localStorage.getItem(this.name);
+      try {
+        var v = window.localStorage.getItem(this.name);
+      } catch (ex) {
+        this.errorMessage = ex.message;
+        console.error("LocalStorage could not be saved. Safari cookies always blocked?", ex);
+      };
 
       if (v === null) {
         this._loaded = true;

--- a/iron-localstorage.html
+++ b/iron-localstorage.html
@@ -183,7 +183,7 @@ is resolved. Local storage will be blown away.
         var v = window.localStorage.getItem(this.name);
       } catch (ex) {
         this.errorMessage = ex.message;
-        console.error("LocalStorage could not be saved. Safari cookies always blocked?", ex);
+        this._error("LocalStorage could not be saved. Safari cookies always blocked?", ex);
       };
 
       if (v === null) {

--- a/iron-localstorage.html
+++ b/iron-localstorage.html
@@ -183,7 +183,8 @@ is resolved. Local storage will be blown away.
         var v = window.localStorage.getItem(this.name);
       } catch (ex) {
         this.errorMessage = ex.message;
-        this._error("LocalStorage could not be saved. Safari cookies always blocked?", ex);
+
+        this._error("Could not save to localStorage.  Try enabling cookies for this page.", ex);
       };
 
       if (v === null) {
@@ -226,7 +227,7 @@ is resolved. Local storage will be blown away.
       catch(ex) {
         // Happens in Safari incognito mode,
         this.errorMessage = ex.message;
-        Polymer.Base._error("localStorage could not be saved. Safari incognito mode?", ex);
+        Polymer.Base._error("Could not save to localStorage. Incognito mode may be blocking this action", ex);
       }
     }
 


### PR DESCRIPTION
This will allow page load to continue in Safari when cookies are set to Always Block whenever a `google-youtube` component is being used.