### PR TITLE
Handle 'storage' event when key isn't set. Fixes #44

### DIFF
--- a/iron-localstorage.html
+++ b/iron-localstorage.html
@@ -146,7 +146,7 @@ is resolved. Local storage will be blown away.
     },
 
     _handleStorage: function(ev) {
-      if (ev.key == this.name) {
+      if (ev.key == this.name || !ev.key) {
         this._load(true);
       }
     },

--- a/test/external-change.html
+++ b/test/external-change.html
@@ -1,0 +1,118 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>iron-localstorage-external-change</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+
+    <script src="../../webcomponentsjs/webcomponents.js"></script>
+    <script src="../../web-component-tester/browser.js"></script>
+    <link rel="import" href="../iron-localstorage.html">
+
+</head>
+<body>
+
+<dom-module id="test-element" is="dom-bind">
+    <template>
+        <iron-localstorage id="localstorage" autoSaveDisabled name="iron-localstorage-test" value="{{value}}"></iron-localstorage>
+    </template>
+</dom-module>
+
+<iframe id="myframe" style="display:none"></iframe>
+
+<script>
+
+    var testElement;
+    var externalWindow;
+    var setLoadEmptyListener;
+
+    suite('external-change', function() {
+
+        suiteSetup(function() {
+            Polymer({
+                is: 'test-element',
+                properties: {
+                    'value': {
+                        type: Object,
+                        notify: true
+                    }
+                }
+            });
+
+            // In order to fire the 'storage' event, create a separate window.
+            externalWindow = document.querySelector('iframe');
+
+            // listener function
+            setLoadEmptyListener = function(done) {
+                // Any external window that manipulates the localStorage will fire a 'storage' event.
+                // iron-localstorage listens for this, handles the event and fires iron-localstorage-load-empty
+                testElement.$.localstorage.addEventListener('iron-localstorage-load-empty', function() {
+                    assert.isNull(testElement.value);
+                    assert.equal(window.localStorage.length,  0);
+                    done();
+
+                });
+            };
+
+        });
+
+        suiteTeardown(function() {
+            window.localStorage.clear();
+        });
+
+        setup(function(done) {
+            // Each test should have its own clean elements.
+            if (testElement) {
+                // remove <test-element>
+                testElement.parentNode.removeChild(testElement);
+            }
+
+            // start with empty local storage
+            window.localStorage.clear();
+
+            // Set test value
+            window.localStorage.setItem('iron-localstorage-test', '{"foo":"bar"}');
+
+            // create (and load) <test-element>
+            testElement = document.createElement('test-element');
+            document.body.appendChild(testElement);
+
+            // listen for load event and make sure everything is loaded correctly
+            testElement.$.localstorage.addEventListener('iron-localstorage-load', function () {
+                var storageValue = JSON.parse(window.localStorage.getItem('iron-localstorage-test'));
+                assert.equal(testElement.value.foo, storageValue.foo);
+                assert.equal(testElement.value.foo, 'bar');
+                done();
+            });
+
+        });
+
+
+        test('clear', function(done) {
+            setLoadEmptyListener(done);
+
+            // clear localStorage initiated by external window
+            externalWindow.contentWindow.localStorage.clear();
+        });
+
+        test('remove item', function(done) {
+            setLoadEmptyListener(done);
+
+            // remove item initiated by window
+            externalWindow.contentWindow.localStorage.removeItem('iron-localstorage-test');
+        });
+    });
+
+</script>
+
+</body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -18,9 +18,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       'basic.html',
       'raw.html',
       'value-binding.html',
+      'external-change.html',
       'basic.html?dom=shadow',
       'raw.html?dom=shadow',
-      'value-binding.html?dom=shadow'
+      'value-binding.html?dom=shadow',
+      'external-change.html?dom=shadow'
     ]);
   </script>
 


### PR DESCRIPTION
Happens when localStorage.clear is called from an external window. Include new test suite for external changes.